### PR TITLE
workaround for insight reporting "Missing inputs" on success

### DIFF
--- a/api.js
+++ b/api.js
@@ -37,7 +37,7 @@ async function transfer(address, key){
 */
 async function getUTXOs(address){
     return new Promise((resolve, reject)=>{
-        insight.getUnspentUtxos(address,(err,unspents)=>{
+        insight.getUtxos(address,(err,unspents)=>{
             if(err){
                 reject("Insight API return Errors: " + err)
             } else {
@@ -53,16 +53,25 @@ async function getUTXOs(address){
 */
 async function broadcast_insight(tx){
     return new Promise((resolve, reject)=>{
-        insight.broadcast(tx.toString(),(err,res)=>{
+        insight.broadcast(tx.toString(),(err,res)=>handleBroadcast(err,res))
+        async function handleBroadcast(err,res){
             if(err){
                 if(err.message && err.message.message)err=err.message.message
                 console.log(" Insight API return Errors: ")
                 console.log(err)
-                reject([tx.id,"Insight API return Errors: " + err])
+                let txexists = await new Promise(resolve=>{
+                    insight.getTransaction(tx.id,(err,res)=>resolve(!err && res))
+                })
+                if (txexists) {
+                    console.log(" However, transaction is actually present.")
+                    resolve(txexists.txid)
+                } else {
+                    reject([tx.id,"Insight API return Errors: " + err])
+                }
             }else{
                 resolve(res)
             }
-        })
+        }
     })
     
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsvup",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Put file/directory on BSV, using D protocol.",
   "main": "index.js",
   "bin": {
@@ -9,7 +9,7 @@
   "unpkg": "bsvup.min.js",
   "dependencies": {
     "bitcoin-ibe": "^1.2.2",
-    "bitcore-explorers": "^1.0.1",
+    "bitcore-explorers": "bitpay/bitcore-explorers#1f1334f7ea7f75ed80f62d379613a961a66403f2",
     "bsv": "^0.27.2",
     "commander": "^2.20.0",
     "inquirer": "^6.5.0",


### PR DESCRIPTION
This is a hacky workaround for #13 that prevents an occasional infinite loop due to how the insight server behaves.  There's probably a much more clean solution out there somewhere, but this does the trick.