### PR TITLE
ensure all outputs meet the dust limit

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -342,7 +342,7 @@ async function fundTasks (tasks, privkey, utxos) {
   API.log(`[+] Funding Tasks`, API.logLevel.INFO)
   // var utxos = await API.getUTXOs(privkey.toAddress().toString())
   // 现在检查是否有足够的Satoshis
-  var satoshisRequired = tasks.reduce((totalRequired, task) => totalRequired += Math.max(DUST_LIMIT, task.satoshis + BASE_TX), 0)
+  var satoshisRequired = tasks.reduce((totalRequired, task) => totalRequired += task.satoshis + BASE_TX + DUST_LIMIT, 0)
   var satoshisProvided = utxos.reduce((totalProvided, utxo) => totalProvided += (utxo.amount) ? Math.round(utxo.amount * 1e8) : utxo.satoshis, 0)
   if (satoshisProvided - satoshisRequired - tasks.length * SIZE_PER_OUTPUT < 0) {
     API.log(`当前地址为 ${privkey.toAddress()}`, API.logLevel.WARNING)
@@ -366,7 +366,7 @@ async function fundTasks (tasks, privkey, utxos) {
     myUtxos.forEach(utxo => mapTX.from(utxo))
     currentTasks.forEach(task => {
       // 创建输出
-      mapTX.to(privkey.toAddress(), Math.max(DUST_LIMIT, task.satoshis + BASE_TX))
+      mapTX.to(privkey.toAddress(), task.satoshis + BASE_TX + DUST_LIMIT)
       // 用刚创建的输出构建UTXO
       task.utxo = {
         privkey: privkey,
@@ -439,7 +439,7 @@ async function fundTasksEx (tasks, address, utxos, signer) {
   utxos.forEach(utxo => mapTX.from(utxo))
   currentTasks.forEach(task => {
     // 创建输出
-    mapTX.to(address, Math.max(DUST_LIMIT, task.satoshis + BASE_TX))
+    mapTX.to(address, task.satoshis + BASE_TX + DUST_LIMIT)
     // 用刚创建的输出构建UTXO
     task.utxo = {
       signer: signer,

--- a/txUtil.js
+++ b/txUtil.js
@@ -46,7 +46,7 @@ function verifyTX (tx) {
         throw new Error(`${tx.id}: Insuffient Satoshis`)
     } else if (!tx.isFullySigned()) throw new Error(`${tx.id}: Not fully signed`)
     else if (tx.toString().length > TX_SIZE_MAX) throw new Error(`${tx.id} Oversized`)
-    else if (!tx.outputs.every(output=>output.satoshis>=546)) throw new Error(`${tx.id} Dust`)
+    else if (!tx.outputs.every(output=>output.satoshis>=DUST_LIMIT)) throw new Error(`${tx.id} Dust`)
     else return true
   }
   
@@ -135,7 +135,7 @@ function buildDOut (dPayload) {
     dPayload.sequence
   ])
   return bsv.Transaction.Output({
-    satoshis: 0,
+    satoshis: DUST_LIMIT,
     script: dScript.toHex()
   })
 }
@@ -150,7 +150,7 @@ function buildBCatOut (bcatPayload) {
     bcatPayload.flag
   ].concat(bcatPayload.chunks.map(txid => Buffer.from(txid, 'hex'))))
   return bsv.Transaction.Output({
-    satoshis: 0,
+    satoshis: DUST_LIMIT,
     script: dScript.toHex()
   })
 }
@@ -161,7 +161,7 @@ function buildBCatPartOut (bcatPartPayload) {
     bcatPartPayload.data
   ])
   return bsv.Transaction.Output({
-    satoshis: 0,
+    satoshis: DUST_LIMIT,
     script: bcatPartScript.toHex()
   })
 }
@@ -175,7 +175,7 @@ function buildBOut (bPayload) {
     bPayload.filename
   ])
   return bsv.Transaction.Output({
-    satoshis: 0,
+    satoshis: DUST_LIMIT,
     script: bScript.toHex()
   })
 }


### PR DESCRIPTION
I noticed you added stricter dust checking at https://github.com/monkeylord/bsvup/blob/master/txUtil.js#L49 .  I googled around, and it looks like the check is right at first glance, so I'm using these changes locally so that the check is passed. (edit: linked check has been changed now.)

Note that genesis sends a misleading '64: dust' error when old-style op_returns are sent (instead of using the bsv library's `SafeData` functions).  I wonder if that misleading error is the reason for the new change.

The impact of adding a dust minimum everywhere could be offset by increasing the maximum transaction size.  I don't know what the new maximum is.

EDIT: it looks like it's 1GB, but mattercloud won't accept a transaction that big.