### PR TITLE
remove redundant fee values and tighten BASE_TX

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -27,8 +27,7 @@ const API = require('./api.js')
 const txutil = require('./txUtil.js')
 
 const CHUNK_SIZE = 64000
-const BASE_TX = 400
-const FEE_PER_KB = 1536
+const BASE_TX = 178
 const DUST_LIMIT = 546
 const MAX_OUTPUT = 1000
 const SIZE_PER_OUTPUT = 100

--- a/txUtil.js
+++ b/txUtil.js
@@ -11,7 +11,6 @@ const bsv = require('bsv')
 const API = require('./api.js')
 
 const CHUNK_SIZE = 64000
-const FEE_PER_KB = 1536
 const BASE_BPART_SIZE = 250
 const BASE_B_SIZE = 300
 const DUST_LIMIT = 546


### PR DESCRIPTION
This removes the fee constants that are no longer used, and tightens BASE_TX up to a smaller value I've been using extensively locally.