### PR TITLE
Revert my commit "propagate outward the renaming of findExist"

### DIFF
--- a/api.js
+++ b/api.js
@@ -169,7 +169,7 @@ async function tryBroadcastAll (TXs) {
     Find exist bsvup B/Bcat record on blockchain.
     We use sha1 as file name.
 */
-async function findMightExist (buf, mime) {
+async function findExist (buf, mime) {
   var sha1 = crypto.createHash('sha1').update(buf).digest('hex')
   log(sha1, logLevel.VERBOSE)
   if (global.quick) return null
@@ -365,7 +365,7 @@ function log (log, level) {
 module.exports = {
   transfer: transfer,
   findD: findD,
-  findMightExist: findMightExist,
+  findExist: findExist,
   tryBroadcastAll: tryBroadcastAll,
   broadcast: broadcast,
   getUTXOs: getUTXOs,

--- a/logic.js
+++ b/logic.js
@@ -123,16 +123,16 @@ async function reduceFileDatum (fileDatum, address) {
   API.log(`[+] Checking Exist Record`, API.logLevel.INFO)
   for (var fileData of fileDatum) {
     API.log(` - Checking ${fileData.dKey}`, API.logLevel.INFO)
-    var fileTX = await API.findMightExist(fileData.buf, fileData.mime)
+    var fileTX = await API.findExist(fileData.buf, fileData.mime)
     if (fileTX) {
-      API.log(`   Data hash found on chain, assuming present.`, API.logLevel.INFO)
+      API.log(`   Data found on chain.`, API.logLevel.INFO)
       fileData.bExist = true
       // fileData.buf = undefined    // Release Buffer
       fileData.dExist = false
       fileData.dValue = fileTX.id
       if (await API.findD(fileData.dKey, address.toString(), fileTX.id)) {
         fileData.dExist = true
-        API.log(`   D Record pointing to hash found on chain.`, API.logLevel.INFO)
+        API.log(`   D Record found on chain.`, API.logLevel.INFO)
       }
     } else {
       fileData.bExist = false


### PR DESCRIPTION
This commit got included in the last PR merge.  Sorry, it was an error.  It is appearance-only.

This reverts commit 03abe75935f03e1ef0a7e8b82f27470cb8c0c865.

This was committed mistakenly, with a misunderstanding how findExist is used.
findExist does correctly verify its content.  There's no reason to tell the user only a hash is used.