### PR TITLE
return a nonzero exitcode when an error is thrown

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -81,11 +81,11 @@ if (process.argv.filter(arg => (arg === '-n' || arg === '--newtask' || arg === '
     } else {
       // 清除未广播的TX
       Cache.abandonUnbroadcast()
-      program.parse(process.argv)
+      program.parseAsync(process.argv).catch(e=>{process.exitCode=1; throw e;})
     }
   })
 } else {
-  program.parse(process.argv)
+  program.parseAsync(process.argv).catch(e=>{process.exitCode=1; throw e;})
 }
 
 async function init () {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bitcoin-ibe": "^1.2.2",
     "bitcore-explorers": "github:bitpay/bitcore-explorers#1f1334f7ea7f75ed80f62d379613a961a66403f2",
     "bsv": "^1.3.0",
-    "commander": "^2.20.0",
+    "commander": "^4.1.1",
     "inquirer": "^6.5.0",
     "mattercloudjs": "^1.0.6",
     "mime": "^2.4.4",


### PR DESCRIPTION
This is a quick change so that when something fails, the exitcode is set.  I'm using node 10 which doesn't yet automatically set exitcode 1 when a promise is rejected.  This PR upgrades the commander dependency to use .parseAsync.