### PR TITLE
[draft] waiting for >1 confirmations

### DIFF
--- a/api.js
+++ b/api.js
@@ -116,7 +116,7 @@ async function broadcast (tx) {
     Try broadcast all transactions given.
     If TXs is null, load transactions from cache.
 */
-async function tryBroadcastAll (TXs) {
+async function tryBroadcastAll (TXs, confirmations) {
   if (TXs) {
     for (let transaction of TXs) {
       Cache.saveTX(transaction, 'unbroadcasted')
@@ -130,6 +130,8 @@ async function tryBroadcastAll (TXs) {
       let txexists = await Backends.findTx(identifier)
       if (txexists.length) {
         if (txexists[0].blk) {
+          // to find the confirmations, we need the length of the chain.
+          // we'd also want to verify the block difficulty is comparable or increases
           log(`Confirmed ${identifier} in block ${txexists[0].blk.h}`, logLevel.INFO)
           let transaction = Cache.loadTX(identifier, 'unbroadcasted')
           Cache.saveTX(transaction)

--- a/backends.js
+++ b/backends.js
@@ -42,7 +42,7 @@ async function findTx (id) {
       },
       'project': {
         'tx.h': 1,
-        'blk.h': 1
+        'blk': 1
       }
     }
   }


### PR DESCRIPTION
It looks like this will need more API interface additions in order to properly discern the transaction depth.  When doing that, it would make sense to get the block difficulty too, to verify the chain could be the real one.  Might leave this PR on hold waiting for the P2P one.  Not sure.  But it's somewhere anybody could start.